### PR TITLE
Make GitHub detect *.nf as Forth.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*nf linguist-language=Forth


### PR DESCRIPTION
Hello,

Please merge this to make GitHub detect your `.nf` files as Forth.

Thanks!
